### PR TITLE
Typo fix in ssl_smart_proxy.rb

### DIFF
--- a/lib/packetthief/handlers/ssl_smart_proxy.rb
+++ b/lib/packetthief/handlers/ssl_smart_proxy.rb
@@ -53,7 +53,7 @@ module PacketThief
 
       # Requests a certificate from the original destination.
       def preflight_for_cert(hostname=nil)
-        logdebug "prefilight for: #{hostname}"
+        logdebug "preflight for: #{hostname}"
         begin
           pfctx = OpenSSL::SSL::SSLContext.new
           pfctx.verify_mode = OpenSSL::SSL::VERIFY_NONE


### PR DESCRIPTION
Trivial change. Found a typo in preflight setup. Fixed it.