### PR TITLE
Changes to allow tlspretense to be run during CI

### DIFF
--- a/lib/tlspretense/app.rb
+++ b/lib/tlspretense/app.rb
@@ -30,7 +30,9 @@ QUOTE
         when 'init'
           InitRunner.new(@action_args, @stdin, @stdout).run
         when 'run'
-          TestHarness::Runner.new(@action_args, @stdin, @stdout).run
+          unless TestHarness::Runner.new(@action_args, @stdin, @stdout).run
+            return 1
+          end
         when 'list', 'ls'
           TestHarness::Runner.new(['--list'] + @action_args, @stdin, @stdout).run
         when 'ca'
@@ -45,8 +47,9 @@ QUOTE
       rescue CleanExitError => e
         @stdout.puts ""
         @stdout.puts "#{e.class}: #{e}"
-        exit 1
+        return 1
       end
+      0
     end
   end
 end

--- a/lib/tlspretense/test_harness/input_handler.rb
+++ b/lib/tlspretense/test_harness/input_handler.rb
@@ -8,12 +8,16 @@ module TestHarness
       @actions = {}
 
       # Set the term to accept keystrokes immediately.
-      @stdin.enable_raw_chars
+      if @stdin.tty?
+        @stdin.enable_raw_chars
+      end
     end
 
     def unbind
       # Clean up by resotring the old termios
-      @stdin.disable_raw_chars
+      if @stdin.tty?
+        @stdin.disable_raw_chars
+      end
     end
 
     # Receives one character at a time.

--- a/lib/tlspretense/test_harness/runner.rb
+++ b/lib/tlspretense/test_harness/runner.rb
@@ -47,6 +47,13 @@ module TestHarness
         stop_packetthief
 
         @report.print_results(@stdout)
+
+        if @report.fail?
+          @stdout.puts 'FAIL'
+        else
+          @stdout.puts 'PASS'
+        end
+        !@report.fail?
       else
         raise "Unknown action: #{opts[:action]}"
       end

--- a/lib/tlspretense/test_harness/ssl_test_report.rb
+++ b/lib/tlspretense/test_harness/ssl_test_report.rb
@@ -21,6 +21,9 @@ module TestHarness
 
     end
 
+    def fail?
+      @results.any? {|r| !r.passed?}
+    end
   end
 end
 end


### PR DESCRIPTION
1. Exit with code 1 if any test is failing, that allows scripts to detect failure easily
2. Allow it to run on non-tty stdin